### PR TITLE
Add python tag

### DIFF
--- a/python-36-support.rst
+++ b/python-36-support.rst
@@ -1,5 +1,6 @@
 .. post:: Mar 29, 2018
     :author: Anthony
+    :tags: python
 
 Python 3.6 Support
 ==================


### PR DESCRIPTION
This adds a Python tag which will let us have a python specific atom feed (`/archive/tag/python/atom.xml`). This is useful for submitting this subset of the blog to syndication services like Planet Python.