### PR TITLE
Add CI and fix requirements and broken links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Build docs
+      run: |
+        make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Build docs
+      env:
+        # Ignore warnings from code we don't have control over
+        PYTHONWARNINGS: ignore:FutureWarning
       run: |
         make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
+        sudo apt install -y libxml2-dev libxslt1-dev
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,5 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Build docs
-      env:
-        # Ignore warnings from code we don't have control over
-        PYTHONWARNINGS: ignore:FutureWarning
       run: |
         make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.7

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sphinx:
+  configuration: conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sphinx:
-  builder: dirthml
+  builder: dirhtml
   configuration: conf.py
 
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,7 @@
 version: 2
 
 sphinx:
+  builder: dirthml
   configuration: conf.py
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python: "3.7"
+install:
+  - pip install -r requirements.txt
+script:
+  - make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python: "3.7"
-install:
-  - pip install -r requirements.txt
-script:
-  - make html

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/ad-blocker-update.rst
+++ b/ad-blocker-update.rst
@@ -8,7 +8,7 @@ Update on Ad Blocking and Acceptable Ads
 ========================================
 
 A few weeks ago, we shared about the
-:doc:`challenge ad blocking presented to our sustainability <ads-and-adblocking>`
+:doc:`challenge ad blocking presented to our sustainability </ads-and-adblocking>`
 and what we were doing about it.
 On May 4th, Read the Docs was added to the `Acceptable Ads list`_
 meaning that our visitors running ad blockers who choose to allow unintrusive advertising
@@ -28,7 +28,7 @@ Data on our inclusion in the Acceptable Ads list
 32% of Read the Docs visitors run an ad blocker
     Estimates around the web vary regarding what percentage of people
     run ad blockers and it varies heavily by industry.
-    We discussed this figure a bit in our :doc:`previous post<ads-and-adblocking>`.
+    We discussed this figure a bit in our :doc:`previous post </ads-and-adblocking>`.
 
 It took a month from application to inclusion in the list
     We discovered about our inclusion in the `EasyList`_ ad blocker list

--- a/ad-funding-read-the-docs-whats-next.rst
+++ b/ad-funding-read-the-docs-whats-next.rst
@@ -6,8 +6,8 @@
 Ad Funding at Read the Docs and What's Next for Ethical Advertising
 ===================================================================
 
-It has been three years since we first launched :doc:`ads on Read the Docs <ads-on-read-the-docs>`
-and while we gave a limited update in our :doc:`2018 stats<read-the-docs-2018-stats>`,
+It has been three years since we first launched :doc:`ads on Read the Docs </ads-on-read-the-docs>`
+and while we gave a limited update in our :doc:`2018 stats </read-the-docs-2018-stats>`,
 we figured it was time to give an update on ethical advertising and how it is working.
 
 
@@ -24,7 +24,7 @@ It's that simple and it works.
 
 Despite a slow start to the year, we expect to earn about $75,000 from advertising in Q2.
 This brings our advertising revenue back to the level
-before our ads were :doc:`added to major ad blocking lists <ads-and-adblocking>` last year.
+before our ads were :doc:`added to major ad blocking lists </ads-and-adblocking>` last year.
 
 While we do earn money from other sources such as our `commercial offering <https://readthedocs.com>`_,
 advertising continues to be our largest source of revenue and has allowed us
@@ -43,10 +43,10 @@ We've made great progress on advertising over the past year.
 * Our `community ads program`_ has been significantly expanded.
   We are actively running free community advertising promoting over ten open source projects and conferences.
 * While we never tracked users with advertising,
-  we put in place stricter :doc:`Do Not Track <do-not-track>` privacy protections.
+  we put in place stricter :doc:`Do Not Track </do-not-track>` privacy protections.
   We continue to believe that advertising can be well targeted without tracking users.
 * We launched an advertising vertical to let companies
-  :doc:`promote their open jobs <lessons-from-hiring-manager-interviews>` to developers.
+  :doc:`promote their open jobs </lessons-from-hiring-manager-interviews>` to developers.
 * Our advertising revenue share program tripled in size.
 
 .. _community ads program: https://docs.readthedocs.io/page/advertising/ethical-advertising.html#community-ads

--- a/adding-markdown-support.rst
+++ b/adding-markdown-support.rst
@@ -15,13 +15,13 @@ we have the ability to support a markup language with a proper spec.
 `recommonmark`_ is the bridge that allows Commonmark to be used inside Sphinx.
 **This allows you to use both RST and Commonmark inside of your Sphinx project.**
 
-.. _Commonmark: http://commonmark.org/
+.. _Commonmark: https://commonmark.org/
 .. _recommonmark: https://github.com/rtfd/recommonmark
 
 Get started
 -----------
 
-We have documented how to `get started`_ with Commonmark inside of Sphinx.
+We have documented how to :ref:`get started <readthedocs:intro/getting-started-with-sphinx:Using Markdown with Sphinx>` with Commonmark inside of Sphinx.
 You simply::
 
     pip install recommonmark
@@ -97,6 +97,4 @@ Go ahead and try it out.
 Please file features ideas and bug reports on the `recommonmark bug tracker`_.
 
 .. _proposed draft: http://talk.commonmark.org/t/generic-directives-plugins-syntax/444
-.. _get started: http://docs.readthedocs.org/en/latest/getting_started.html#in-markdown
 .. _recommonmark bug tracker: https://github.com/rtfd/recommonmark/issues
-

--- a/ads-and-adblocking.rst
+++ b/ads-and-adblocking.rst
@@ -7,7 +7,7 @@
 Ads and Ad blockers
 ===================
 
-Last time, we shared how :doc:`ethical advertising works <ethical-advertising-works>`
+Last time, we shared how :doc:`ethical advertising works </ethical-advertising-works>`
 to keep Read the Docs sustainable without creepy ad targeting.
 This time, we will share about one of our biggest challenges with advertising.
 At the beginning of April, Read the Docs was added to one of the most popular
@@ -140,4 +140,4 @@ If you run an open source project affected by ad blockers, we would love to help
     audience who cares deeply about privacy,
     we would love to `hear from you`_ too.
 
-    .. _hear from you: https://readthedocs.org/sustainability/advertising/#advertise-cta
+    .. _hear from you: https://readthedocs.org/sustainability/advertising/

--- a/ads-on-other-themes.rst
+++ b/ads-on-other-themes.rst
@@ -4,7 +4,7 @@
 Ads on the Alabaster Theme on Read the Docs Community Sites
 ===========================================================
 
-We've been running our `ethical advertising <http://docs.readthedocs.io/en/latest/ethical-advertising.html>`_ campaign for over a year now,
+We've been running our :doc:`ethical advertising <readthedocs:advertising/ethical-advertising>` campaign for over a year now,
 and it is starting to show success on making Read the Docs more sustainable. 
 
 Over this time,
@@ -56,7 +56,7 @@ In particular:
 * Projects that opt out of normal advertising, as previously supported, will now be shown *only* ads from our Community Ads partners.
 * Users will be able to opt out of all paid ads with a profile setting, but will still see Community Ads.
 
-You can `learn more <http://docs.readthedocs.io/en/latest/ethical-advertising.html#opting-out>`_ about opting out in our docs.
+You can :ref:`learn more <readthedocs:advertising/ethical-advertising:Opting Out>` about opting out in our docs.
 
 Community Ads
 ~~~~~~~~~~~~~

--- a/ads-with-sentry.rst
+++ b/ads-with-sentry.rst
@@ -4,7 +4,7 @@
 Running ads with Sentry
 =======================
 
-We're excited to announce our first partner in our `Ethical Advertising`_
+We're excited to announce our first partner in our :doc:`Ethical Advertising <readthedocs:advertising/ethical-advertising>`
 campaign: `Sentry`_.
 
 Sentry was a natural first partner,
@@ -32,7 +32,6 @@ We wholeheartedly recommend their product, and thank them for their sponsorship.
    :width: 330px
    :align: center
 
-.. _Ethical Advertising: http://docs.readthedocs.io/en/latest/ethical-advertising.html
 .. _Sentry: https://sentry.io/
 .. _Django REST framework: https://fund.django-rest-framework.org/topics/funding/
 .. _Django: https://www.djangoproject.com/fundraising/

--- a/ads-with-uniregistry.rst
+++ b/ads-with-uniregistry.rst
@@ -8,7 +8,7 @@ Uniregistry sponsors Read the Docs and Open Source
    :width: 100%
    :target: https://uniregistry.com/readthedocs
 
-Today we're excited to announce an important sponsorship partner in our `Ethical Advertising`_ campaign: `Uniregistry`_. Our goal with our ethical advertising program is to provide important funding for open source, and show that it can be done ethically -- without tracking our users and only offering ads from relevant partners. 
+Today we're excited to announce an important sponsorship partner in our :doc:`Ethical Advertising <readthedocs:advertising/ethical-advertising>` campaign: `Uniregistry`_. Our goal with our ethical advertising program is to provide important funding for open source, and show that it can be done ethically -- without tracking our users and only offering ads from relevant partners. 
 
 Domain registration was identified early as a natural partner to our program, because it sits in the stack of necessary infrastructure for all of us that work on making the internet. We wanted the right partner, because historically we feel that domain registration companies have had awful UX. We'll cover a few of the criteria we used to reach the conclusion to partner with Uniregistry.
 
@@ -76,7 +76,6 @@ and find it as useful as we do.
 Some small print: *Terms: Offer valid from March 31, 2017 to May 31, 2017 at 23:59:59 UTC for first year registrations and/or transfers in to Uniregistry.com. Excludes select extensions: .sucks & .game. Not including premiums. For redemption, you must have or create a new account at Uniregistry.com and comply with all Uniregistry.com registration policies and terms of service. Cannot be used in conjunction with any other offer, sale, discount or promotion; not redeemable for any other service; no cash value. This offer and all Uniregistry registration services are governed by the law of Grand Cayman, our home.*
 
 
-.. _Ethical Advertising: http://docs.readthedocs.io/en/latest/ethical-advertising.html
 .. _Uniregistry: https://uniregistry.com/readthedocs
 .. _Try it: https://uniregistry.com/readthedocs
 .. _Sign up: https://uniregistry.com/readthedocs

--- a/building-docs-for-pull-requests.rst
+++ b/building-docs-for-pull-requests.rst
@@ -4,7 +4,7 @@
    :location: DHA
 
 GSOC 2019: Autobuild Documentation for Pull Requests
-===================================================
+====================================================
 
 Building documentation for pull requests is one of the most requested features of Read the Docs.
 Similar to how a continuous integration system runs a test suite on every pull request,

--- a/conf.py
+++ b/conf.py
@@ -239,7 +239,7 @@ htmlhelp_basename = 'ReadtheDocsBlogdoc'
 
 intersphinx_mapping = {
     'readthedocs': (
-        'https://docs.readthedocs.io/en/latest',
+        'https://docs.readthedocs.io/en/stable',
         None
     ),
 }

--- a/conf.py
+++ b/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Read the Docs Blog documentation build configuration file, created by
 # sphinx-quickstart on Thu Jul 31 11:23:11 2014.
 #

--- a/do-not-track.rst
+++ b/do-not-track.rst
@@ -25,7 +25,7 @@ What we implemented
 
 Not much needed to change to make Read the Docs support DNT
 and many of these changes were already necessary
-for the EU's new :doc:`privacy regulation <gdpr-what-it-means-for-readthedocs>`.
+for the EU's new :doc:`privacy regulation </gdpr-what-it-means-for-readthedocs>`.
 
 Here's a brief list of what we did for Do Not Track:
 
@@ -45,7 +45,7 @@ What DNT means for our advertising
 ----------------------------------
 
 Advertising at Read the Docs was already built with privacy in mind.
-With our `Ethical Ads`_, we previously committed to not tracking users,
+With our :doc:`Ethical Ads <readthedocs:advertising/ethical-advertising>`, we previously committed to not tracking users,
 not selling user data, and hosting ads ourselves
 which all align perfectly with Do Not Track.
 
@@ -53,13 +53,10 @@ Our support for DNT formalizes our commitment to the high standards
 for privacy produced by the EFF.
 It also make us one of very few ad networks that honor Do Not Track.
 
-.. _Ethical Ads: https://docs.readthedocs.io/en/latest/ethical-advertising.html
-
-
 The Ethical Ad Network
 ----------------------
 
-In a :doc:`previous post <ethical-advertising-works>`,
+In a :doc:`previous post </ethical-advertising-works>`,
 we mentioned that we are taking the same developer-centric, privacy-focused
 advertising we have on Read the Docs and expanding this to a larger ad network
 for open source infrastructure.

--- a/ethical-advertising-works.rst
+++ b/ethical-advertising-works.rst
@@ -4,7 +4,7 @@
 Ethical Advertising Works
 =========================
 
-It has been two years since we first launched :doc:`ads on Read the Docs <ads-on-read-the-docs>`.
+It has been two years since we first launched :doc:`ads on Read the Docs </ads-on-read-the-docs>`.
 We figured it was time to report on the results that we've seen,
 and say thanks to those who have helped us along the way.
 

--- a/exts/atom_absolute.py
+++ b/exts/atom_absolute.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
-
 import os.path
 
 from lxml import etree, html
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 from sphinx.util import logging
 
 

--- a/fixed-footer-ad-all-themes.rst
+++ b/fixed-footer-ad-all-themes.rst
@@ -16,14 +16,14 @@ via our revenue share program and grants.
 
 Currently, about 30% of our site traffic does not have any advertising.
 When we first launched ethical advertising in 2016,
-we launched only on :doc:`specific documentation themes <ads-on-other-themes>`.
+we launched only on :doc:`specific documentation themes </ads-on-other-themes>`.
 We purposely did this slowly to make sure our ads look integrated
 with Read the Docs and less obtrusive to users.
 
 For a while, this wasn't a problem because we had not reached capacity with advertising.
 We did not have enough paid advertisers to support the amount of pageviews Read the Docs served.
 Fast forward a couple years,
-and our advertising model has :doc:`proven to be successful <ad-funding-read-the-docs-whats-next>`.
+and our advertising model has :doc:`proven to be successful </ad-funding-read-the-docs-whats-next>`.
 In North America and Western Europe,
 **100% of pages that are eligible for paid advertising have a paid ad**.
 

--- a/gdpr-what-it-means-for-readthedocs.rst
+++ b/gdpr-what-it-means-for-readthedocs.rst
@@ -69,7 +69,7 @@ That's because:
 
 By enforcing privacy by default, the GDPR shifts the discussion on advertising.
 We want to create an advertising model that is a win for all parties especially users.
-We know from our experience that :doc:`ethical advertising works <ethical-advertising-works>`.
+We know from our experience that :doc:`ethical advertising works </ethical-advertising-works>`.
 It is possible to make money without giving away your users data.
 
 If you want to learn more about Ethical Ads at Read the Docs, please `get in touch`_!

--- a/improved-search-and-search-as-you-type.rst
+++ b/improved-search-and-search-as-you-type.rst
@@ -38,7 +38,7 @@ Background
 
 The search code was originally contributed by `Rob Hudson`_,
 `back in 2013`_ and then improved upon by other contributors.
-It was greatly improved and upgraded by `Safwan Rahman`_ during :doc:`GSoC'18 <search-improvements>`.
+It was greatly improved and upgraded by `Safwan Rahman`_ during :doc:`GSoC'18 </search-improvements>`.
 Continuing on the same path,
 I have implemented some new features on top of the existing search backend.
 

--- a/lessons-from-hiring-manager-interviews.rst
+++ b/lessons-from-hiring-manager-interviews.rst
@@ -13,7 +13,7 @@ with the ultimate goal of building a product to help companies find developers.
 We talked to people looking for talent at five person companies all the way up to the biggest names in tech.
 In this post, I am going to cover some of the common things we heard from hiring managers
 and **share some ways for hiring managers to improve their company's process**.
-In our :doc:`next post in this series <tips-for-getting-a-developer-interview>`, I will have some actionable tips
+In our :doc:`next post in this series </tips-for-getting-a-developer-interview>`, I will have some actionable tips
 for job seekers based on the same interviews.
 
 Since this is a long post, I figured I'd share some of the key takeaways:
@@ -36,7 +36,7 @@ Why is Read the Docs tackling hiring? Hasn't that been done?
 ------------------------------------------------------------
 
 While we didn't initially think about Read the Docs ads for recruiting,
-based on some :doc:`unexpected past successes <hiring-developers-with-readthedocs>`,
+based on some :doc:`unexpected past successes </hiring-developers-with-readthedocs>`,
 we decided to position promoted jobs as one of our main verticals within our advertising.
 Rather than dash forward and create a product, however, we started by just talking to hiring managers
 to understand the hiring process better so we can best meet their needs with something we create.
@@ -191,10 +191,10 @@ I'd like to thank all the hiring managers who took time out of their days (or in
 If you're a hiring manager or an internal company recruiter and you'd like to share your experiences and help Read the Docs,
 please `get in touch <mailto:ads@readthedocs.org?subject=Lessons+From+Hiring+Managers+Post>`_.
 
-Check back soon for our :doc:`next post in this series <tips-for-getting-a-developer-interview>`
+Check back soon for our :doc:`next post in this series </tips-for-getting-a-developer-interview>`
 which covers tips for candidates based on the same interviews!
 
-**Update:** This blog was updated to mention our :doc:`new post <tips-for-getting-a-developer-interview>` in the series
+**Update:** This blog was updated to mention our :doc:`new post </tips-for-getting-a-developer-interview>` in the series
 
 
 .. admonition:: Ready to hire your next developer, fast!

--- a/new-theme-read-the-docs.rst
+++ b/new-theme-read-the-docs.rst
@@ -141,5 +141,5 @@ help `fund development on Read the Docs`_ on Gittip.
 .. _Read the Docs: http://readthedocs.org/
 .. _Dave Snider: https://twitter.com/enemykite
 .. _open an issue: http://github.com/snide/sphinx_rtd_theme/issues
-.. _theme documentation page: http://docs.readthedocs.org/en/latest/theme.html
+.. _theme documentation page: https://sphinx-rtd-theme.readthedocs.io/en/stable/
 .. _us on Twitter: http://twitter.com/readthedocs

--- a/python-36-support.rst
+++ b/python-36-support.rst
@@ -14,15 +14,15 @@ build image.
 
 In the near future, this build image will be the default build image, but for
 now, you can manually opt your project in using our
-:doc:`YAML configuration file <readthedocs:yaml-config>`.
+:doc:`YAML configuration file <readthedocs:config-file/v2>`.
 
 What you need
 -------------
 
 In order to use Python 3.6, you need to select our ``latest`` build image, and
 you need to select to use Python 3.6. The build image is controlled with the
-:ref:`readthedocs:yaml__build__image` setting in the YAML config, and you can
-set the Python version with the :ref:`readthedocs:yaml__python__version`
+:ref:`readthedocs:config-file/v2:build.image` setting in the YAML config, and you can
+set the Python version with the :ref:`readthedocs:config-file/v2:python.version`
 setting.
 
 Your project's ``readthedocs.yml`` file should contain::

--- a/read-the-docs-2018-stats.rst
+++ b/read-the-docs-2018-stats.rst
@@ -83,10 +83,10 @@ Funding
 * $16,000 from Gold users (up 16%)
 * We have additional revenue from our commercial offering at readthedocs.com, but aren't including that in our community funding overview
 
-The biggest impact to our revenue this year was :doc:`our ads being blocked <ads-and-adblocking>`.
+The biggest impact to our revenue this year was :doc:`our ads being blocked </ads-and-adblocking>`.
 This happened in May,
 and caused an initial 32% reduction in our ad revenue.
-We were :doc:`added to the Acceptable Ads <ad-blocker-update>` list later in the month,
+We were :doc:`added to the Acceptable Ads </ad-blocker-update>` list later in the month,
 which regained around half of our revenue.
 So for the second half of the year,
 our ad revenue was down about 15%.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-Sphinx<1.8>1.7
-six
+Sphinx==1.7.9
 
 # Used to rewrite the Atom feed to use absolute links
 lxml==4.2.1
 
-# https://github.com/abakan/ablog/pull/93
-git+https://github.com/tadeboro/ablog@cc099ccdfac85a4c2f4a64ecf04e17b3019ce5a7#egg=ablog-dev
+ablog==0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ Sphinx==1.7.9
 lxml==4.2.1
 
 ablog==0.9.5
+# This dependencie from ablog needs to be pinned
+werkzeug==0.16.1

--- a/seo-for-technical-docs.rst
+++ b/seo-for-technical-docs.rst
@@ -123,7 +123,7 @@ Feedback on keywords users use to find your docs is also really helpful.
 This is true both for the phrases people searched for on a search engine
 and for the search terms people queried in Sphinx and Read the Docs' built-in search features.
 Analytics tools like Google Analytics can provide these insights,
-but as part of our :doc:`search improvements and search analytics <improved-search-and-search-as-you-type>`,
+but as part of our :doc:`search improvements and search analytics </improved-search-and-search-as-you-type>`,
 Read the Docs is going to show project maintainers the most common search queries to help them improve as well.
 
 

--- a/tips-for-getting-a-developer-interview.rst
+++ b/tips-for-getting-a-developer-interview.rst
@@ -13,7 +13,7 @@ at companies ranging from 5-person companies to the biggest names in tech.
 We wanted to learn more about hiring processes at various companies
 with the ultimate goal of building `a product to help companies find developers`_.
 
-Last time, we covered some :doc:`tips for hiring managers <lessons-from-hiring-manager-interviews>`
+Last time, we covered some :doc:`tips for hiring managers </lessons-from-hiring-manager-interviews>`
 based on what companies told us they were doing.
 This time, we put together **tips for candidates looking for their next job**
 based on insights we heard from hiring managers.
@@ -60,7 +60,7 @@ that requires a cover letter or requires answers to a few questions,
 those are great ways to have your application stand out relative to other applicants.
 You don't want your resume to get lost in a stack of hundreds.
 
-As we mentioned :doc:`last time <lessons-from-hiring-manager-interviews>`,
+As we mentioned :doc:`last time </lessons-from-hiring-manager-interviews>`,
 quite a few hiring managers we talked to started requiring a cover letter
 or even just a couple questions that are unique to the company
 in order to make their job filtering candidates easier


### PR DESCRIPTION
The branch/fork that we were installing ablog from was deleted, so we can't build the blog anymore. The ablog project was moved the sunpy org (https://github.com/abakan-zz/ablog/pull/93#issuecomment-366457676), the latest version to support sphinx 1.7 is `0.9.5`. Updating to sphinx > 1.8 breaks the custom CSS we have for the blog (we should try updating it in another moment anyway).

I also started to use `-W` to treat warnings as errors, and found some broken links and setup CI using github actions.

The blog looks the same as far I was able to see updating to 0.9.5