### PR TITLE
Updates on Project Privacy Levels

### DIFF
--- a/project-privacy-levels-update.rst
+++ b/project-privacy-levels-update.rst
@@ -1,0 +1,44 @@
+.. post:: Jan 14, 2021
+   :tags: privacy-levels, deprecation
+   :author: Santos
+   :location: CUE
+
+Updates on Project Privacy Levels
+=================================
+
+In order to simplify our platform,
+we are dropping privacy levels for projects in Read the Docs (community version).
+This was source of confusion between been able to hide your documentation,
+and hide the dashboard of your project,
+project privacy levels were meant for the later.
+
+This change will take effect on **May 31st, 2021**.
+Note that **only the dashboard of your projects will be public**
+(e.g. https://readthedocs.org/projects/docs/),
+**their documentation has always been public** (e.g. https://docs.readthedocs.io/).
+
+.. note::
+
+   This change is only for the community version of Read the Docs (https://readthedocs.org).
+   Privacy levels for `projects <https://docs.readthedocs.io/page/commercial/privacy-level.html>`__
+   and `versions <https://docs.readthedocs.io/page/versions.html#privacy-levels>`__
+   in Read the Docs for Business (https://readthedocs.com) always will be available.
+
+How do I know if my project is private?
+---------------------------------------
+
+.. TODO: show the privacy level of projects in the dashboard
+
+Additionally, in the following weeks we'll be contacting users that have private projects.
+
+What do I need to do with my private projects?
+----------------------------------------------
+
+If you think there is private information in the dashboard of your project (like the builds page or its description),
+you can delete the project in order to keep that information out of the public.
+Otherwise, you don't have to do anything.
+
+If you are looking to hide your public versions,
+check out `hidden versions <https://docs.readthedocs.io/page/versions.html#version-states>`__.
+If you need to host private projects,
+please use `Read the Docs for Business <https://readthedocs.com>`__.


### PR DESCRIPTION
We need to

- Decide on a date to make the change
- Optionally make it obvious if a project is private in the UI in .org
- Optionally merge https://github.com/readthedocs/readthedocs.org/pull/7608
- Mail all users with private/protected projects in .org about this change (maybe twice?)
- Do a data migration
  - For .org private/protected to public
  - For .com protected to private

Try it to keep it short and clear, hopefully isn't confusing :D