### PR TITLE
Add the open position to the blog sidebar

### DIFF
--- a/_themes/rtd-blog/social.html
+++ b/_themes/rtd-blog/social.html
@@ -14,8 +14,16 @@ Sign up for our blog and we'll send you information about Sphinx and Read the Do
     </div>
 </form>
 </div>
-
 <!--End mc_embed_signup-->
+
+
+<!-- Jobs -->
+<h3> Read the Docs is hiring </h3>
+<ul>
+	<li><a href="https://blog.readthedocs.com/job-frontend/">Front-end Developer</a></li>
+	<li><a href="https://www.ethicalads.io/jobs/account-manager-part-time/">Part-time Ads Account Manager</a></li>
+</ul>
+
 
 <h3> Follow us </h3>
 

--- a/jobs.rst
+++ b/jobs.rst
@@ -1,0 +1,28 @@
+:orphan:
+
+.. meta::
+   :description: We don't always have openings to work at Read the Docs, but when we do they are posted here
+   :keywords: jobs, hiring
+
+Jobs at Read the Docs
+=====================
+
+Thanks for your interest in working at Read the Docs.
+We are a small team growing slowly and deliberately,
+and we’d love for you to join us.
+
+Jobs at Read the Docs
+---------------------
+
+These are jobs working on our core documentation products:
+
+* `Front-end developer with design skills <https://blog.readthedocs.com/job-frontend/>`_
+
+Jobs at EthicalAds
+------------------
+
+These are our advertising-specific openings working on our ethical ad network:
+
+* `Ads Account Manager (Part Time) <https://www.ethicalads.io/jobs/account-manager-part-time/>`_
+
+


### PR DESCRIPTION
I purposefully used absolute links because relative links might break on some pages (eg. https://blog.readthedocs.com/archive/2017/)