### PR TITLE
Temporarily post-date October newsletter

### DIFF
--- a/newsletter-october-2021.rst
+++ b/newsletter-october-2021.rst
@@ -1,4 +1,4 @@
-.. post:: October 6, 2021
+.. post:: October 7, 2021
    :tags: newsletter, python
    :author: Juan Luis
    :location: MAD


### PR DESCRIPTION
So it gets sent on the email newsletter.

It didn't get sent, because I had canceled and resumed the campaign *after* I published the blog post. Now I know.

I'll merge, and tomorrow I'll revert.