### PR TITLE
Revert #188

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,6 @@ version: 2
 sphinx:
   builder: dirhtml
   configuration: conf.py
-  fail_on_warning: true
 
 python:
   version: 3.7

--- a/_themes/rtd-blog/static/local.css
+++ b/_themes/rtd-blog/static/local.css
@@ -1,41 +1,32 @@
-h1, h2, h3, h4, h5, h6
-{
-  margin: 1em 0;
-}
-
-section h1 {
+div.section h1 {
     font-size: 1.3em;
 }
 
-section h2 {
+div.section h2 {
     font-size: 1.2em;
 }
 
-section h3 {
+div.section h3 {
     font-size: 1.1em;
 }
 
-section h4, section h5, section h6 {
+div.section h4, div.section h5, div.section h6 {
     font-size: 1em;
 }
 
-section ul {
-    list-style: disc;
-    margin: 1em 0 1em 2em;
+div.section ul {
+    list-style: inside;
+    margin: 1em;
 }
 
-section ul li p {
-    margin: 0;
-}
-
-section p {
-    margin: .75rem 0;
+div.section p {
+    margin: .75rem .5rem;
     line-height: 1.6rem;
 }
 
-section ul li,
+div.section ul li,
 div.sidebar ul li {
-    margin: .5em 0;
+    margin: .5em;
     line-height: 1.4em;
 }
 
@@ -85,7 +76,7 @@ dl.docutils dd p, dl dd p {
 }
 
 div.admonition {
-    padding: 1rem 1rem 0.5rem 1rem;
+    padding: .65em;
     margin: 1em 0em;
     border-radius: .3em;
     -moz-border-radius: .3em;
@@ -95,48 +86,24 @@ div.admonition {
 
 div.admonition p.admonition-title {
     font-weight: bold;
-    margin-top: 0;
 }
 
-dl.footnote {
-  margin: 0.5rem 0;
-  display: table;
+table.footnote {
+    margin: 1em;
 }
 
-dl.footnote dt {
-  display: table-cell;
-  white-space: nowrap;
-  width: 1%;
-  margin-left: 1rem;
-  margin-right: 1rem;
-  margin-top: 0;  
-}
-
-dl.footnote dd > p:first-child {
-  display: table-cell;
-  margin: 0px;
-}
-
-dl.footnote .brackets:before {
-  content: "["
-}
-dl.footnote .brackets:after {
-  content: "]"
-}
-
-.postlist {
-  margin: 1em 0;
+table.footnote td.label {
+    padding: .65em;
 }
 
 .postlist li {
     list-style: none;
-    margin-bottom: 2rem;
 }
 
-.postlist p.first, .postlist .ablog-post-title {
+.postlist p.first {
     font-size: 24px;
-    margin-bottom: 0.5rem;
 }
+
 
 img.align-center {
     display: block;
@@ -152,14 +119,14 @@ div.highlight pre {
 }
 
 /* Optimize figure CSS */
-figure {
+div.figure {
   text-align: center;
   margin: 2em 0;
 }
-figure img {
+div.figure img {
   max-width: 100%;
 }
-figure figcaption {
+div.figure p.caption {
   font-size: 85%;
   line-height: 1.4;
   margin-left: 2.5rem;

--- a/_themes/rtd-blog/static/main.css
+++ b/_themes/rtd-blog/static/main.css
@@ -1094,7 +1094,7 @@ select.dropdown {
 #content > .wrapper div.col-minor {
   display: block;
   overflow: hidden;
-  padding-left: 1.5em;
+  padding-left: 1em;
 }
 @media (max-width: 1000px) {
   #content > .wrapper {

--- a/announcing-pydoc-io.rst
+++ b/announcing-pydoc-io.rst
@@ -45,9 +45,7 @@ On top of that,
 we've layered a few different tools:
 
 * `sphinx-autoapi`_ which is the tool that takes Python source files and turns them into rST.
-
-  * Internally, this uses the `pydocstyle`_ AST parser, which we use for a parse-only representation of the Python files.
-
+   * Internally, this uses the `pydocstyle`_ AST parser, which we use for a parse-only representation of the Python files.
 * `pydoc.io`_ is a Django application that is the actual web front-end and documentation building code.
 * `sphinx-apitheme`_ is the Sphinx theme that powers the actual API listing pages.
 

--- a/conf.py
+++ b/conf.py
@@ -81,6 +81,8 @@ templates_path.append(os.path.join(
 ))
 templates_path.append(ablog.get_html_templates_path())
 
+html4_writer = True
+
 if os.environ.get('READTHEDOCS', None) == 'True':
     skip_pickling = True
 
@@ -96,7 +98,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Read the Docs Blog'
-copyright = u'Read the Docs, Inc'
+copyright = u'2021, Read the Docs, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/embed-api-v3.rst
+++ b/embed-api-v3.rst
@@ -65,7 +65,7 @@ and with it, version 1.0 of sphinx-hoverxref**.
 
 Among other things,
 the new versions allow you to
-:ref:`embed content from pages hosted outside Read the Docs <readthedocs:guides/embedding-content:embedding content from your documentation>`.
+:ref:`embed content from pages hosted outside Read the Docs <guides/embedding-content:embedding content from your documentation>`.
 For security reasons, we have an allowlist of such external domains
 that currently includes Python, NumPy, SciPy, SymPy,
 and we would like to
@@ -84,7 +84,7 @@ Embedding content with sphinx-hoverxref
 ---------------------------------------
 
 To use sphinx-hoverxref in your Read the Docs project,
-:doc:`declare it as part of your dependencies <readthedocs:guides/reproducible-builds>`:
+:doc:`declare it as part of your dependencies <guides/reproducible-builds>`:
 
 .. code-block::
    :caption: requirements.txt

--- a/newsletter-december-2021.rst
+++ b/newsletter-december-2021.rst
@@ -34,8 +34,8 @@ New features
   now they have a dedicated section in the project settings,
   you can customize the payload,
   and you can inspect the status of each webhook delivery.
-  Interested in receiving build notifications on :ref:`Slack <readthedocs:guides/build-notifications:slack>`
-  or :ref:`Discord <readthedocs:guides/build-notifications:discord>`? Now you can!
+  Interested in receiving build notifications on :ref:`Slack <readthedocs:build-notifications:slack>`
+  or :ref:`Discord <readthedocs:build-notifications:discord>`? Now you can!
 
 .. figure:: /img/webhooks-events.png
    :align: center

--- a/newsletter-november-2022.rst
+++ b/newsletter-november-2022.rst
@@ -49,8 +49,6 @@ We don't have anything firm to announce here yet,
 but we do plan to be more active in removing these features in the coming months.
 
 
-.. _november2022_tip_of_the_month
-
 Tip of the month
 ----------------
 

--- a/newsletter-november-2022.rst
+++ b/newsletter-november-2022.rst
@@ -49,6 +49,8 @@ We don't have anything firm to announce here yet,
 but we do plan to be more active in removing these features in the coming months.
 
 
+.. _november2022_tip_of_the_month
+
 Tip of the month
 ----------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-Sphinx==5.3.0
+Sphinx==2.4.4
 sphinxext-opengraph==0.4.2
 docutils<0.18
-# jinja2<3.1.0
+jinja2<3.1.0
 
 # Used to rewrite the Atom feed to use absolute links
-lxml==4.9.1
+lxml==4.6.5
 
-ablog==0.10.26
+ablog==0.9.5
 # This dependencie from ablog needs to be pinned
-# werkzeug==0.16.1
+werkzeug==0.16.1


### PR DESCRIPTION
This reverts changes in #188 because of reversed atom feed order.

Note: We should probably still keep an eye on the newsletter service since reversing the RSS might make it send out the same newsletter once again :smiling_face_with_tear: 