### PR TITLE
Post: small post about "latest core requirements"

### DIFF
--- a/python-core-requirements-changed.rst
+++ b/python-core-requirements-changed.rst
@@ -1,0 +1,25 @@
+.. post:: July 7, 2023
+   :tags: builders
+   :author: Manuel
+   :location: BCN
+   :category: Changelog
+
+Python "core requirements" installed by default have changed
+============================================================
+
+Starting on **August 7, 2023** all new projects imported on Read the Docs
+will install only ``sphinx``, ``mkdocs`` and ``readthedocs-sphinx-ext`` as "core requirements".
+Besides, the new behavior will install the latest version of these requirements.
+
+Note that previously Read the Docs was installing also
+``jinja``, ``sphinx-rtd-theme``, ``pillow``, ``mock``, ``alabaster``, ``commonmark`` and ``recommonmark``
+specifying particular versions depending on different factors that were confusing for users and hard to debug.
+
+We are moving away from executing commands and installing dependencies on behalf of the users
+and trying to make the build experience on Read the Docs the same as building locally,
+without surprises.
+
+Projects imported previous to August 7, 2023 will keep the actual behavior and won't be affected by this change.
+If you have a project you want to install the latest version of these requirements,
+you can use a ``requirements.txt`` file to specify their versions.
+Read more about :doc:`how to use a requirements.txt file in our documentation <readthedocs:config-file/v2>`.

--- a/python-core-requirements-changed.rst
+++ b/python-core-requirements-changed.rst
@@ -4,12 +4,12 @@
    :location: BCN
    :category: Changelog
 
-Python "core requirements" installed by default have changed
-============================================================
+Python "core requirements" for new projects will install latest version
+=======================================================================
 
 Starting on **August 7, 2023** all new projects imported on Read the Docs
 will install only ``sphinx``, ``mkdocs`` and ``readthedocs-sphinx-ext`` as "core requirements".
-Besides, the new behavior will install the latest version of these requirements.
+The default behavior will be to install the latest version of these requirements.
 
 Note that previously Read the Docs was installing also
 ``jinja``, ``sphinx-rtd-theme``, ``pillow``, ``mock``, ``alabaster``, ``commonmark`` and ``recommonmark``
@@ -19,7 +19,7 @@ We are moving away from executing commands and installing dependencies on behalf
 and trying to make the build experience on Read the Docs the same as building locally,
 without surprises.
 
-Projects imported previous to August 7, 2023 will keep the actual behavior and won't be affected by this change.
+Projects imported before August 7, 2023 will keep the existing behavior and won't be affected by this change.
 If you have a project you want to install the latest version of these requirements,
-you can use a ``requirements.txt`` file to specify their versions.
+you can use a ``requirements.txt`` file to specify their versions, or no version to automatically install the latest version.
 Read more about :doc:`how to use a requirements.txt file in our documentation <readthedocs:config-file/v2>`.

--- a/python-core-requirements-changed.rst
+++ b/python-core-requirements-changed.rst
@@ -1,4 +1,4 @@
-.. post:: July 7, 2023
+.. post:: July 10, 2023
    :tags: builders
    :author: Manuel
    :location: BCN


### PR DESCRIPTION
Announce the changes made at
https://github.com/readthedocs/readthedocs.org/pull/10508/

Note that we are not exposing this feature flag to our users. We don't want them to contact us to enable this flag. If they need to install the latest versions they can just specify them in their `requirements.txt` file.