### PR TITLE
Post: doctools without configuration file deprecation announcement

### DIFF
--- a/doctool-without-configuration-file.rst
+++ b/doctool-without-configuration-file.rst
@@ -7,19 +7,20 @@
 Doctools without configuration file (`conf.py` / `mkdocs.yml`) are deprecated
 =============================================================================
 
-Historically, Read the Docs has created a ``docs/conf.py`` file for Sphinx projects
-and a ``mkdocs.yml`` file for MkDocs projects that don’t provide one, to make onboarding easier.
-This has been confusing a lot our users in different ways and
-**we will remove the auto-creation of a default Sphinx/MkDocs configuration file for projects that don’t have one on August 28th**.
-To avoid unexpected behavior or your documentation builds failing,
+Historically Read the Docs has created a `conf.py` file for Sphinx projects and a `mkdocs.yml` file for MkDocs projects that don't provide one,
+to make onboarding easier. 
+This has been confusing a lot our users in different ways and **we will remove the auto-creation of a default Sphinx/MkDocs configuration file for projects that don't have one on August 28th**. 
+To avoid unexpected behavior or your documentation builds failing, 
 you should add a configuration file to your project by this date.
 
-You can find a good example of a basic configuration file in our :doc:`example projects <readthedocs:examples>`:
+The auto-creation of a default configuration file will be completely removed on **August 28th**. Add a `conf.py`/`mkdocs.yml` to your projects before this date to avoid unexpected build failures.
 
-* Sphinx `example conf.py <https://github.com/readthedocs-examples/example-sphinx-basic/blob/main/docs/conf.py>`_
-* Mkdocs `example mkdocs.yml <https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml`_
+You can find a good example of a basic configuration file in our [example projects](https://docs.readthedocs.io/en/stable/examples.html):
 
+* Sphinx [example conf.py](https://github.com/readthedocs-examples/example-sphinx-basic/blob/main/docs/conf.py)
+* Mkdocs [example mkdocs.yml](https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml)
 
-Please, `contact us`_ and let us know any inconvenient you may have with this change.
+Please `contact us`_ about any issues you have regarding change.
 
 .. _contact us: mailto:hello@readthedocs.org
+

--- a/doctool-without-configuration-file.rst
+++ b/doctool-without-configuration-file.rst
@@ -1,0 +1,25 @@
+.. post:: July 12, 2023
+   :tags: builders
+   :author: Manuel
+   :location: BCN
+   :category: Changelog
+
+Doctools without configuration file (`conf.py` / `mkdocs.yml`) are deprecated
+=============================================================================
+
+Historically, Read the Docs has created a ``docs/conf.py`` file for Sphinx projects
+and a ``mkdocs.yml`` file for MkDocs projects that don’t provide one, to make onboarding easier.
+This has been confusing a lot our users in different ways and
+**we will remove the auto-creation of a default Sphinx/MkDocs configuration file for projects that don’t have one on August 28th**.
+To avoid unexpected behavior or your documentation builds failing,
+you should add a configuration file to your project by this date.
+
+You can find a good example of a basic configuration file in our :doc:`example projects <readthedocs:examples>`:
+
+* Sphinx `example conf.py <https://github.com/readthedocs-examples/example-sphinx-basic/blob/main/docs/conf.py>`_
+* Mkdocs `example mkdocs.yml <https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml`_
+
+
+Please, `contact us`_ and let us know any inconvenient you may have with this change.
+
+.. _contact us: mailto:hello@readthedocs.org

--- a/doctool-without-configuration-file.rst
+++ b/doctool-without-configuration-file.rst
@@ -18,7 +18,7 @@ The auto-creation of a default configuration file will be completely removed on 
 You can find a good example of a basic configuration file in our :doc:`example projects <readthedocs:examples>`:
 
 * Sphinx `example conf.py <https://github.com/readthedocs-examples/example-sphinx-basic/blob/main/docs/conf.py>`_
-* Mkdocs `example mkdocs.yml <https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml`_
+* Mkdocs `example mkdocs.yml <https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml>`_
 
 Please `contact us`_ about any issues you have regarding change.
 

--- a/doctool-without-configuration-file.rst
+++ b/doctool-without-configuration-file.rst
@@ -15,10 +15,10 @@ you should add a configuration file to your project by this date.
 
 The auto-creation of a default configuration file will be completely removed on **August 28th**. Add a `conf.py`/`mkdocs.yml` to your projects before this date to avoid unexpected build failures.
 
-You can find a good example of a basic configuration file in our [example projects](https://docs.readthedocs.io/en/stable/examples.html):
+You can find a good example of a basic configuration file in our :doc:`example projects <readthedocs:examples>`:
 
-* Sphinx [example conf.py](https://github.com/readthedocs-examples/example-sphinx-basic/blob/main/docs/conf.py)
-* Mkdocs [example mkdocs.yml](https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml)
+* Sphinx `example conf.py <https://github.com/readthedocs-examples/example-sphinx-basic/blob/main/docs/conf.py>`_
+* Mkdocs `example mkdocs.yml <https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/mkdocs.yml`_
 
 Please `contact us`_ about any issues you have regarding change.
 


### PR DESCRIPTION
Follows https://github.com/readthedocs/readthedocs.org/issues/2483