### PR TITLE
Post: "Builds with no `index.html` file"

### DIFF
--- a/build-errors-docutils-0-18.rst
+++ b/build-errors-docutils-0-18.rst
@@ -112,7 +112,7 @@ If you still experience problems, feel free to
 `open an issue <https://github.com/readthedocs/readthedocs.org/issues/>`_.
 
 .. seealso::
-    :doc:`readthedocs:guides/setup/configuration-file`
+    :doc:`readthedocs:config-file/index`
         An introduction to our configuration file and some basic usage examples
 
     :ref:`.readthedocs.yaml python.install options <readthedocs:config-file/v2:python.install>`

--- a/builds-without-index.rst
+++ b/builds-without-index.rst
@@ -7,18 +7,15 @@
 Builds with no ``index.html`` at its output's directory are deprecated
 ======================================================================
 
-Historically, Read the Docs has created an auto-generated ``index.html`` file with minimal instructions about how to setup the project correctly
-for those builds that weren't outputting this file.
-This auto-generated file has confused more users than helped them.
-Mainly, because the behavior on Read the Docs was different from the behavior on their local environment.
+Historically, Read the Docs has created an auto-generated ``index.html`` file with minimal instructions about how to setup the project correctly when your build didn’t output this file.
+This auto-generated file has confused more users than it has helped because the behavior on Read the Docs was different from the behavior on their local environment.
 
-Due to this, we decided to stop creating the ``index.html`` file automatically.
-Besides, we will check for an ``index.html`` file at the end of the build,
-and fail it with a clear message of the problem if there is no ``index.html`` file in the ``$READTHEDOCS_OUTPUT/html`` directory.
-This will help users to immediately understand what's the problem and how to solve it.
+To better onboard users, we have deprecated the auto-creation of ``index.html`` files on Read the Docs projects.
+We will now check for an ``index.html`` file at the end of the build,
+and fail it with a clear message of the problem if there is no ``index.html`` file in the top level of your output directory.
 
-Builds from projects that are not generating an ``index.html`` file **will start to fail on August 1st at ~9AM PST**, after our regular deploy.
-Make sure your project is properly configured and it's creating an ``index.html`` file before that date to avoid unexpected behaviors.
+Builds from projects that are not generating an ``index.html`` file **will start to fail on August 1st**.
+Make sure your project is properly configured and it’s creating an ``index.html`` file before that date to avoid unexpected behaviors.
 
 We recommend you following our :doc:`tutorial <readthedocs:tutorial/index>` to set up your project correctly.
 

--- a/builds-without-index.rst
+++ b/builds-without-index.rst
@@ -1,0 +1,27 @@
+.. post:: July 20, 2023
+   :tags: builders
+   :author: Manuel
+   :location: BCN
+   :category: Changelog
+
+Builds with no ``index.html`` at its output's directory are deprecated
+======================================================================
+
+Historically, Read the Docs has created an auto-generated ``index.html`` file with minimal instructions about how to setup the project correctly
+for those builds that weren't outputting this file.
+This auto-generated file has confused more users than helped them.
+Mainly, because the behavior on Read the Docs was different from the behavior on their local environment.
+
+Due to this, we decided to stop creating the ``index.html`` file automatically.
+Besides, we will check for an ``index.html`` file at the end of the build,
+and fail it with a clear message of the problem if there is no ``index.html`` file in the ``$READTHEDOCS_OUTPUT/html`` directory.
+This will help users to immediately understand what's the problem and how to solve it.
+
+Builds from projects that are not generating an ``index.html`` file **will start to fail on August 1st at ~9AM PST**, after our regular deploy.
+Make sure your project is properly configured and it's creating an ``index.html`` file before that date to avoid unexpected behaviors.
+
+We recommend you following our :doc:`tutorial <readthedocs:tutorial>` to set up your project correctly.
+
+Please, `contact us`_ and let us know any inconvenient you may have with this change.
+
+.. _contact us: mailto:hello@readthedocs.org

--- a/builds-without-index.rst
+++ b/builds-without-index.rst
@@ -1,4 +1,4 @@
-.. post:: July 20, 2023
+.. post:: July 25, 2023
    :tags: builders
    :author: Manuel
    :location: BCN

--- a/builds-without-index.rst
+++ b/builds-without-index.rst
@@ -20,7 +20,7 @@ This will help users to immediately understand what's the problem and how to sol
 Builds from projects that are not generating an ``index.html`` file **will start to fail on August 1st at ~9AM PST**, after our regular deploy.
 Make sure your project is properly configured and it's creating an ``index.html`` file before that date to avoid unexpected behaviors.
 
-We recommend you following our :doc:`tutorial <readthedocs:tutorial>` to set up your project correctly.
+We recommend you following our :doc:`tutorial <readthedocs:tutorial/index>` to set up your project correctly.
 
 Please, `contact us`_ and let us know any inconvenient you may have with this change.
 

--- a/migrate-configuration-v2.rst
+++ b/migrate-configuration-v2.rst
@@ -122,7 +122,7 @@ you should be able to define a working configuration file and avoid breaking cha
 
 .. seealso::
   
-   :doc:`readthedocs:guides/setup/configuration-file`
+   :doc:`readthedocs:config-file/index`
       More usage examples and guidance can be found in our how-to for adding a ``.readthedocs.yaml`` configuration file.
 
 

--- a/newsletter-july-2023.rst
+++ b/newsletter-july-2023.rst
@@ -26,7 +26,7 @@ News and updates
   including the latest stable versions of Python, PyPy, Node.js, Rust and Go.
   See the documentation of the `build.tools <https://docs.readthedocs.io/page/config-file/v2.html#build-tools>`__ for more info.
 - 📚️ A new documentation how-to for ``.readthedocs.yaml`` was started at `Write the Docs <https://www.writethedocs.org/>`__ and finished recently.
-  Read it here: :doc:`readthedocs:guides/setup/configuration-file`.
+  Read it here: :doc:`readthedocs:config-file/index`.
 - ⏩️ HTTP speedups: Several HTTP endpoints and CloudFlare configurations have been tweaked and are performing better.
 - 🐛️ Bug fix: We are now 100% relying on search indexing by parsing HTML, instead of special Sphinx-only logic. This makes search a lot simpler and more consistent for our users.
 


### PR DESCRIPTION
Minimal changelog post announcing https://github.com/readthedocs/readthedocs.org/issues/1800

Currently, we are logging this projects, but on August 1st we will be failing builds that do not generate an `index.html` on the output's directory.